### PR TITLE
when updating children in a to-many relation, dont create duplicate join-table records

### DIFF
--- a/spec/nested_attribute_reassignable_spec.rb
+++ b/spec/nested_attribute_reassignable_spec.rb
@@ -495,4 +495,36 @@ describe NestedAttributeReassignable do
       end
     end
   end
+
+  context 'when has_and_belongs_to_many' do
+    let!(:math) { Clique.create!(name: 'math club') }
+    let!(:chess) { Clique.create!(name: 'chess club') }
+
+    context 'on create' do
+      it 'should create associations' do
+        p = Person.create!(cliques_attributes: [{ id: math.id }, { id: chess.id }])
+        expect(p.reload.cliques).to eq([math, chess])
+      end
+    end
+
+    context 'on update' do
+      let!(:instance) { Person.create!(cliques_attributes: [{ id: math.id }]) }
+
+      it 'should add records to the association' do
+        instance.update_attributes(cliques_attributes: [{ id: chess.id }])
+        expect(instance.reload.cliques).to eq([math, chess])
+      end
+
+      it 'should update the associated record' do
+        instance.update(cliques_attributes: [{ id: math.id, name: 'math clan' }])
+        expect(math.reload.name).to eq('math clan')
+      end
+
+      it 'should not create duplicate join-table records' do
+        expect(instance.cliques.count).to eq(1)
+        instance.update(cliques_attributes: [{ id: math.id, name: 'math clan' }])
+        expect(instance.cliques.count).to eq(1)
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,7 +37,13 @@ ActiveRecord::Schema.define(:version => 1) do
     t.string :name
   end
 
-  create_table :pets do |t|
+  create_table :cliques do |t|
+    t.string :name
+  end
+
+  create_join_table :people, :cliques
+
+  create_table :pets do |t|1
     t.belongs_to :person, index: true
     t.string :name
   end
@@ -71,6 +77,7 @@ class Person < ApplicationRecord
   has_many :pets
   has_one :office
   belongs_to :family
+  has_and_belongs_to_many :cliques
 
   has_many :bills
   has_many :services, through: :bills, dependent: :destroy
@@ -78,8 +85,13 @@ class Person < ApplicationRecord
   reassignable_nested_attributes_for :pets
   reassignable_nested_attributes_for :office
   reassignable_nested_attributes_for :family
+  reassignable_nested_attributes_for :cliques
 
   reassignable_nested_attributes_for :services, lookup_key: :name
+end
+
+class Clique < ApplicationRecord
+  has_and_belongs_to_many :people
 end
 
 class SpecialPerson < ApplicationRecord


### PR DESCRIPTION
Marking this as "proposal" because it changes the behavior of the `has_many :through` case (eg when the join table has semantic meaning, such as person<-bill->service in the spec). However, I am not sure what the intended behavior in that case actually is, because there is not a spec describing it. If it's intended that additional join-table records *should* be created in `has_many :through`, some additional check of the association will be needed.